### PR TITLE
Bugfix whitespace newlines

### DIFF
--- a/lib/HTML/Packer.pm
+++ b/lib/HTML/Packer.pm
@@ -109,7 +109,7 @@ our $NEWLINES = [
             my $ret;
 
             if ( $pre eq '>' or $post eq '<' ) {
-                $ret = $pre . $post;
+                $ret = $pre . ' ' . $post;
             }
             elsif ( $pre =~ /[\w-]/ and $post =~ /[\w-]/ ) {
                 $ret = $pre . ' ' . $post;

--- a/t/02-io.t
+++ b/t/02-io.t
@@ -82,7 +82,7 @@ my $html_input = <<EOT;
 
 EOT
 
-my $html_expected       = '<script>alert(\'test\');</script><br><img src="/bild.jpg" alt="hmpf"> <a href="/">link 1 </a> <a href="/"> link 2 </a>';
+my $html_expected       = '<script>alert(\'test\');</script> <br> <img src="/bild.jpg" alt="hmpf"> <a href="/">link 1 </a> <a href="/"> link 2 </a>';
 my $html_expected_no_js = '<script>/*<![CDATA[*/' . "\n\n\n\n  " . 'alert(\'test\');/*]]>*/</script><br><img src="/bild.jpg" alt="hmpf"> <a href="/">link 1 </a> <a href="/"> link 2 </a>';
 
 my $not = 11;

--- a/t/02-io.t
+++ b/t/02-io.t
@@ -83,7 +83,7 @@ my $html_input = <<EOT;
 EOT
 
 my $html_expected       = '<script>alert(\'test\');</script> <br> <img src="/bild.jpg" alt="hmpf"> <a href="/">link 1 </a> <a href="/"> link 2 </a>';
-my $html_expected_no_js = '<script>/*<![CDATA[*/' . "\n\n\n\n  " . 'alert(\'test\');/*]]>*/</script><br><img src="/bild.jpg" alt="hmpf"> <a href="/">link 1 </a> <a href="/"> link 2 </a>';
+my $html_expected_no_js = '<script>/*<![CDATA[*/' . "\n\n\n\n  " . 'alert(\'test\');/*]]>*/</script> <br> <img src="/bild.jpg" alt="hmpf"> <a href="/">link 1 </a> <a href="/"> link 2 </a>';
 
 my $not = 11;
 

--- a/t/html/s2-expected.html
+++ b/t/html/s2-expected.html
@@ -1,1 +1,1 @@
-<a href="/">link 1 </a><!-- comment --><a href="/"> link 2 </a>
+<span>bla</span> <span>bla</span> <a href="/">link 1 </a><!-- comment --><a href="/"> link 2 </a>

--- a/t/html/s2.html
+++ b/t/html/s2.html
@@ -1,4 +1,5 @@
-
+<span>bla</span>
+<span>bla</span>
 
 <a href="/"  >link 
 


### PR DESCRIPTION
Enters have meaning as white space in html (https://www.w3.org/TR/html5/infrastructure.html#space-character). So removing a newline without regard for context can result in altering the html.

E.g.

``` html
<span>blah</span>
<span>blah</span>
```

should render with a space as

```
blah blah
```
