### PR TITLE
Fix #8: proper newlines replacement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ perl:
     - "5.14"
     - "5.12"
     - "5.10"
-    - "5.8"
 
 before_install:
     - git clone git://github.com/haarg/perl-travis-helper

--- a/lib/HTML/Packer.pm
+++ b/lib/HTML/Packer.pm
@@ -108,14 +108,11 @@ our $NEWLINES = [
 
             my $ret;
 
-            if ( $pre eq '>' or $post eq '<' ) {
-                $ret = $pre . ' ' . $post;
-            }
-            elsif ( $pre =~ /[\w-]/ and $post =~ /[\w-]/ ) {
-                $ret = $pre . ' ' . $post;
+            if ( $pre eq '>' and $post eq '<' ) {
+                $ret = $pre . $post;
             }
             else {
-                $ret = $pre . $post;
+                $ret = $pre . ' ' . $post;
             }
 
             return $ret;

--- a/lib/HTML/Packer.pm
+++ b/lib/HTML/Packer.pm
@@ -111,6 +111,9 @@ our $NEWLINES = [
             if ( $pre eq '>' and $post eq '<' ) {
                 $ret = $pre . $post;
             }
+            elsif ( $pre eq '-' and $post =~ /[\w]/ ) {
+                $ret = $pre . $post;
+            }
             else {
                 $ret = $pre . ' ' . $post;
             }

--- a/t/02-io.t
+++ b/t/02-io.t
@@ -82,7 +82,7 @@ my $html_input = <<EOT;
 
 EOT
 
-my $html_expected       = '<script>alert(\'test\');</script> <br> <img src="/bild.jpg" alt="hmpf"> <a href="/">link 1 </a> <a href="/"> link 2 </a>';
+my $html_expected       = '<script>alert(\'test\');</script><br><img src="/bild.jpg" alt="hmpf"> <a href="/">link 1 </a> <a href="/"> link 2 </a>';
 my $html_expected_no_js = '<script>/*<![CDATA[*/' . "\n\n\n\n  " . 'alert(\'test\');/*]]>*/</script><br><img src="/bild.jpg" alt="hmpf"> <a href="/">link 1 </a> <a href="/"> link 2 </a>';
 
 my $not = 11;

--- a/t/02-io.t
+++ b/t/02-io.t
@@ -83,7 +83,7 @@ my $html_input = <<EOT;
 EOT
 
 my $html_expected       = '<script>alert(\'test\');</script> <br> <img src="/bild.jpg" alt="hmpf"> <a href="/">link 1 </a> <a href="/"> link 2 </a>';
-my $html_expected_no_js = '<script>/*<![CDATA[*/' . "\n\n\n\n  " . 'alert(\'test\');/*]]>*/</script> <br> <img src="/bild.jpg" alt="hmpf"> <a href="/">link 1 </a> <a href="/"> link 2 </a>';
+my $html_expected_no_js = '<script>/*<![CDATA[*/' . "\n\n\n\n  " . 'alert(\'test\');/*]]>*/</script><br><img src="/bild.jpg" alt="hmpf"> <a href="/">link 1 </a> <a href="/"> link 2 </a>';
 
 my $not = 11;
 

--- a/t/html/s2-expected.html
+++ b/t/html/s2-expected.html
@@ -1,1 +1,1 @@
-<span>bla</span> <span>bla</span> <a href="/">link 1 </a><!-- comment --><a href="/"> link 2 </a>
+<span>bla</span><span>bla</span> <a href="/">link 1 </a><!-- comment --><a href="/"> link 2 </a>

--- a/t/html/s2-expected.html
+++ b/t/html/s2-expected.html
@@ -1,1 +1,1 @@
-<span>bla</span><span>bla</span> <a href="/">link 1 </a><!-- comment --><a href="/"> link 2 </a>
+<span>bla</span><span>bla</span> <a href="/">link 1 </a><!-- comment --><a href="/"> link 2 </a> The database employs a number of cutting-edge technologies such as cache-conscious lock-free burst hash trie for the index, NUMA-aware records distribution and replication, and so on.

--- a/t/html/s2.html
+++ b/t/html/s2.html
@@ -11,4 +11,7 @@
     <  a href="/">   link 2   
     < / a  >
 
+The database employs a number of cutting-edge technologies such as cache-
+conscious lock-free burst hash trie for the index,
+NUMA-aware records distribution and replication, and so on.
 


### PR DESCRIPTION
Fix newlines replacement:
1. Do not put a space between opened and closed tags.
2. Do put spaces between various punctuation characters and words.