### PR TITLE
add 'remove_comments_aggressive' boolean flag (see #11)

### DIFF
--- a/lib/HTML/Packer.pm
+++ b/lib/HTML/Packer.pm
@@ -12,7 +12,7 @@ our $VERSION = '2.06';
 
 our @BOOLEAN_ACCESSORS = (
     'remove_comments',
-    'remove_comments_safe',
+    'remove_comments_aggressive',
     'remove_newlines',
     'no_compress_comment',
     'html5',
@@ -192,7 +192,7 @@ sub do_stylesheet {
 # to a reference cycle and thus memory leak, and we can't scope them to
 # the init method as they may change. they are set by the minify sub
 our $remove_comments;
-our $remove_comments_safe;
+our $remove_comments_aggressive;
 our $remove_newlines;
 our $html5;
 our $do_javascript;
@@ -225,7 +225,7 @@ sub init {
             }
         },
         {
-            regexp      => $remove_comments_safe ? $COMMENT_SAFE : $COMMENT,
+            regexp      => $remove_comments_aggressive ? $COMMENT : $COMMENT_SAFE,
             replacement => sub {
                 return $remove_comments ? (
                     $remove_newlines ? ' ' : (
@@ -369,7 +369,7 @@ sub minify {
 
 	# (re)initialize variables used in the closures
 	$remove_comments = $self->remove_comments;
-	$remove_comments_safe = $self->remove_comments_safe;
+	$remove_comments_aggressive = $self->remove_comments_aggressive;
 	$remove_newlines = $self->remove_newlines;
 	$html5           = $self->html5;
 	$do_javascript   = $self->do_javascript;
@@ -472,12 +472,12 @@ Second argument must be a hashref of options. Possible options are
 
 =item remove_comments
 
-HTML-Comments will be removed if 'remove_comments' has a true value.
+HTML-Comments will be removed if 'remove_comments' has a true value.  Comments starting with C<<!--#>,
+C<<!--[> or C<<!-- google_ad_section_> will be preserved unless 'remove_comments_aggressive' has a true value. 
 
-=item remove_comments_safe
+=item remove_comments_aggressive
 
-HTML-Comments starting with C<<!--#>, C<<!--[> or C<<!-- google_ad_section_> will be preserved if
-'remove_comments_safe' has a true value. Requires 'remove_comments' to be set to take effect.
+See 'remove_comments'; requires 'remove_comments' to be set to take effect.
 
 =item remove_newlines
 

--- a/lib/HTML/Packer.pm
+++ b/lib/HTML/Packer.pm
@@ -12,6 +12,7 @@ our $VERSION = '2.06';
 
 our @BOOLEAN_ACCESSORS = (
     'remove_comments',
+    'remove_comments_safe',
     'remove_newlines',
     'no_compress_comment',
     'html5',
@@ -36,7 +37,8 @@ our @VOID_ELEMENTS = (
 
 # Some regular expressions are from HTML::Clean
 
-our $COMMENT        = '((?>\s*))(<!--(?:(?![#\[]| google_ad_section_).*?)?-->)((?>\s*))';
+our $COMMENT        = '((?>\s*))(<!--(?:.*?)?-->)((?>\s*))';
+our $COMMENT_SAFE   = '((?>\s*))(<!--(?:(?![#\[]| google_ad_section_).*?)?-->)((?>\s*))';
 
 our $PACKER_COMMENT = '<!--\s*HTML::Packer\s*(\w+)\s*-->';
 
@@ -190,6 +192,7 @@ sub do_stylesheet {
 # to a reference cycle and thus memory leak, and we can't scope them to
 # the init method as they may change. they are set by the minify sub
 our $remove_comments;
+our $remove_comments_safe;
 our $remove_newlines;
 our $html5;
 our $do_javascript;
@@ -222,7 +225,7 @@ sub init {
             }
         },
         {
-            regexp      => $COMMENT,
+            regexp      => $remove_comments_safe ? $COMMENT_SAFE : $COMMENT,
             replacement => sub {
                 return $remove_comments ? (
                     $remove_newlines ? ' ' : (
@@ -366,6 +369,7 @@ sub minify {
 
 	# (re)initialize variables used in the closures
 	$remove_comments = $self->remove_comments;
+	$remove_comments_safe = $self->remove_comments_safe;
 	$remove_newlines = $self->remove_newlines;
 	$html5           = $self->html5;
 	$do_javascript   = $self->do_javascript;
@@ -469,6 +473,11 @@ Second argument must be a hashref of options. Possible options are
 =item remove_comments
 
 HTML-Comments will be removed if 'remove_comments' has a true value.
+
+=item remove_comments_safe
+
+HTML-Comments starting with C<<!--#>, C<<!--[> or C<<!-- google_ad_section_> will be preserved if
+'remove_comments_safe' has a true value. Requires 'remove_comments' to be set to take effect.
 
 =item remove_newlines
 

--- a/t/02-io.t
+++ b/t/02-io.t
@@ -85,7 +85,7 @@ EOT
 my $html_expected       = '<script>alert(\'test\');</script><br><img src="/bild.jpg" alt="hmpf"> <a href="/">link 1 </a> <a href="/"> link 2 </a>';
 my $html_expected_no_js = '<script>/*<![CDATA[*/' . "\n\n\n\n  " . 'alert(\'test\');/*]]>*/</script><br><img src="/bild.jpg" alt="hmpf"> <a href="/">link 1 </a> <a href="/"> link 2 </a>';
 
-my $not = 11;
+my $not = 12;
 
 SKIP: {
     eval { use HTML::Packer; };
@@ -100,6 +100,7 @@ SKIP: {
     minTest( 's4', { remove_comments => 1, remove_newlines => 1 }, 'Test remove_newlines and remove_comments.' );
     minTest( 's5', { remove_comments => 1, remove_newlines => 1 }, 'Test _no_compress_ comment.' );
     minTest( 's6', { remove_comments => 1, remove_newlines => 1, no_compress_comment => 1 }, 'Test _no_compress_ comment with no_compress_comment option.' );
+    minTest( 's7', { remove_comments => 1, remove_comments_aggressive => 1 }, 'Test aggresive comment removal.' );
 
     my $packer = HTML::Packer->init();
     my $js_comp_input   = $js_input;

--- a/t/html/s7-expected.html
+++ b/t/html/s7-expected.html
@@ -1,0 +1,8 @@
+<a href="/">link
+1 </a>
+<a href="/"> link 2
+</a>
+<a href="/">link 3
+1 </a>
+<a href="/"> link 4
+</a>

--- a/t/html/s7.html
+++ b/t/html/s7.html
@@ -1,0 +1,37 @@
+
+
+<a href="/"  >link
+
+1   < /a>
+
+
+<!-- comment -->
+
+    <  a href="/">   link 2
+    < / a  >
+
+
+<!--[if lte IE 6]><iframe frameborder="0" src="javascript:'&lt;html&gt;&lt;/html&gt;'"></iframe><![endif]-->
+
+
+<a href="/"  >link 3
+
+1   < /a>
+
+
+<!-- google_ad_section_start -->
+
+    <  a href="/">   link 4
+    < / a  >
+
+
+  <!-- google_ad_section_end -->
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
~~Right now, this changes the default behaviour from 'never remove some comments' to 'remove all comments and only preserve some if explicitly said so'. This is in my opinion the approach to take, however, changing the defaults might not be what you want.~~

~~If so, I can rename 'remove_comments_safe' to 'remove_comments_aggressive' and invert its function --it's up to you.~~

edit: github likes this: fix #11 