### PR TITLE
Allow Inheritance by Avoiding `__PACKAGE__`

### DIFF
--- a/lib/HTML/Packer.pm
+++ b/lib/HTML/Packer.pm
@@ -323,7 +323,7 @@ sub minify {
 
     unless (
         ref( $_[0] ) and
-        ref( $_[0] ) eq __PACKAGE__
+        $_[0]->isa( __PACKAGE__ )
     ) {
         $self = __PACKAGE__->init();
 
@@ -381,7 +381,7 @@ sub minify {
 	$reggrp_ws       = $self->reggrp_whitespaces;
 
 	# FIXME: hacky way to get around ->init being called before ->minify
-	$self = __PACKAGE__->init if $remove_comments_aggressive;
+	$self = ref( $self )->init if $remove_comments_aggressive;
 
     $self->reggrp_global()->exec( $html );
     $self->reggrp_whitespaces()->exec( $html );
@@ -522,6 +522,7 @@ Johnson (LEEJO) with contributions from:
 	Alexander Krizhanovsky <ak@natsys-lab.com>
 	Bas Bloemsaat <bas@bloemsaat.com>
 	girst <girst@users.noreply.github.com>
+	Ankit Pati (ANKITPATI) <contact@ankitpati.in>
 
 =head1 BUGS
 


### PR DESCRIPTION
The `ref( $whatever ) eq __PACKAGE__` construct does not work from packages inheriting through `use base` or `use parent`.

Also, indirection through the `__PACKAGE__->subroutine` construct harms inheritance as `__PACKAGE__` is resolved at compile-time, unlike `ref`, which is deferred until run-time.