### PR TITLE
CSP Hashes for Embedded `<script>` & `<style>`

### DIFF
--- a/lib/HTML/Packer.pm
+++ b/lib/HTML/Packer.pm
@@ -5,6 +5,7 @@ use strict;
 use warnings;
 use Carp;
 use Regexp::RegGrp;
+use Digest::SHA qw(sha256_base64 sha384_base64 sha512_base64);
 
 # -----------------------------------------------------------------------------
 
@@ -20,6 +21,7 @@ our @BOOLEAN_ACCESSORS = (
 
 our @JAVASCRIPT_OPTS    = ( 'clean', 'obfuscate', 'shrink', 'best' );
 our @CSS_OPTS           = ( 'minify', 'pretty' );
+our @CSP_OPTS           = ( 'sha256', 'sha384', 'sha512' );
 
 our $REQUIRED_JAVASCRIPT_PACKER = '1.002001';
 our $REQUIRED_CSS_PACKER        = '1.000001';
@@ -187,6 +189,21 @@ sub do_stylesheet {
     return $self->{_do_stylesheet};
 }
 
+sub do_csp {
+    my ( $self, $value ) = @_;
+
+    if ( defined( $value ) ) {
+        if ( grep( $value eq $_, @CSP_OPTS ) ) {
+            $self->{_do_csp} = $value;
+        }
+        elsif ( ! $value ) {
+            $self->{_do_csp} = undef;
+        }
+    }
+
+    return $self->{_do_csp};
+}
+
 # these variables are used in the closures defined in the init function
 # below - we have to use globals as using $self within the closures leads
 # to a reference cycle and thus memory leak, and we can't scope them to
@@ -197,8 +214,10 @@ our $remove_newlines;
 our $html5;
 our $do_javascript;
 our $do_stylesheet;
+our $do_csp;
 our $js_packer;
 our $css_packer;
+our %csp;
 our $reggrp_ws;
 
 sub init {
@@ -271,6 +290,11 @@ sub init {
                                 $content = '/*<![CDATA[*/' . $content . '/*]]>*/';
                             }
                         }
+
+                        if ( $do_csp ) {
+                            no strict 'refs';
+                            push @{ $csp{'script-src'} }, &{ "${do_csp}_base64" } ( $content );
+                        }
                     }
                     elsif ( $opening =~ /$opening_style_re/i ) {
                         $opening =~ s/ type="text\/css"//i if ( $html5 );
@@ -278,6 +302,11 @@ sub init {
                         if ( $css_packer and $do_stylesheet ) {
                             $css_packer->minify( \$content, { compress => $do_stylesheet } );
                             $content = "\n" . $content if ( $do_stylesheet eq 'pretty' );
+                        }
+
+                        if ( $do_csp ) {
+                            no strict 'refs';
+                            push @{ $csp{'style-src'} }, &{ "${do_csp}_base64" } ( $content );
                         }
                     }
                 }
@@ -360,6 +389,7 @@ sub minify {
 
         $self->do_javascript( $opts->{do_javascript} ) if ( defined( $opts->{do_javascript} ) );
         $self->do_stylesheet( $opts->{do_stylesheet} ) if ( defined( $opts->{do_stylesheet} ) );
+        $self->do_csp( $opts->{do_csp} ) if ( defined( $opts->{do_csp} ) );
     }
 
     if ( not $self->no_compress_comment() and ${$html} =~ /$PACKER_COMMENT/s ) {
@@ -376,9 +406,13 @@ sub minify {
 	$html5           = $self->html5;
 	$do_javascript   = $self->do_javascript;
 	$do_stylesheet   = $self->do_stylesheet;
+	$do_csp          = $self->do_csp;
 	$js_packer       = $self->javascript_packer;
 	$css_packer      = $self->css_packer;
 	$reggrp_ws       = $self->reggrp_whitespaces;
+
+    # blank out the CSP hash before populating it again
+    %csp = ();
 
 	# FIXME: hacky way to get around ->init being called before ->minify
 	$self = ref( $self )->init if $remove_comments_aggressive;
@@ -432,6 +466,17 @@ sub css_packer {
     }
 
     return $self->{_css_packer};
+}
+
+sub csp {
+    my $self = shift;
+
+    return 'script-src' => [ ], 'style-src' => [ ] unless $do_csp and %csp;
+
+    return
+        'script-src' => [ map "'$do_csp-$_='", @{ $csp{'script-src'} } ],
+        'style-src' => [ map "'$do_csp-$_='", @{ $csp{'style-src'} } ],
+    ;
 }
 
 1;
@@ -500,6 +545,16 @@ Defines compression level for CSS. Possible values are 'minify' and 'pretty'.
 Default is no compression for CSS.
 This option only takes effect if L<CSS::Packer> is installed.
 
+=item do_csp
+
+Defines hash algorithm for C<Content-Security-Policy>, or CSP, hashes of
+embedded C<E<lt>scriptE<gt>> and C<E<lt>styleE<gt>> tags.
+
+Allowed values are C<'sha256'>, C<'sha384'>, C<'sha512'>.
+
+It may be left blank or set to a Perl false value to indicate that hashes
+should not be calculated, if performance is a concern.
+
 =item no_compress_comment
 
 If not set to a true value it is allowed to set a HTML comment that prevents the input being packed.
@@ -511,6 +566,18 @@ Is not set by default.
 =item html5
 
 If set to a true value closing slashes will be removed from void elements.
+
+=item csp
+
+If C<do_csp> is set to C<'sha256'>, returns a hash that looks like this:
+
+    (
+        'script-src' => [qw( sha256-...= sha256-...= )],
+        'style-src'  => [qw( sha256-...= sha256-...= )],
+    )
+
+with each element of the C<ARRAY>refs containing a CSP-friendly hash for a
+C<E<lt>scriptE<gt>> or C<E<lt>styleE<gt>> tag.
 
 =back
 

--- a/t/gh-16_content_security_policy_hashes.t
+++ b/t/gh-16_content_security_policy_hashes.t
@@ -1,0 +1,256 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use HTML::Packer;
+
+use Test::More tests => 7;
+
+my @tests = (
+    {
+        description => 'blank html',
+        config => {
+            do_csp => 'sha256',
+        },
+        csp => {
+            'script-src' => [qw(
+            )],
+            'style-src' => [qw(
+            )],
+        },
+        html => <<'EOS',
+EOS
+    },
+    {
+        description => 'blank html, blank hash name',
+        config => {
+            do_csp => '',
+        },
+        csp => {
+            'script-src' => [qw(
+            )],
+            'style-src' => [qw(
+            )],
+        },
+        html => <<'EOS',
+EOS
+    },
+    {
+        description => '<script> & <style> in <head>, sha256',
+        config => {
+            do_csp => 'sha256',
+            html5 => 1,
+        },
+        csp => {
+            'script-src' => [qw(
+                'sha256-791JliCfVfBg+ax8zg5KqhP+kgkqzbJzBcpFDrZQnkc='
+            )],
+            'style-src' => [qw(
+                'sha256-gpov5n8Iw6K+eZE3oYxcBsd5VOOwt1qfH39cYA1/dIg='
+            )],
+        },
+        html => <<'EOS',
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Hello!</title>
+        <script>
+            alert("hello, world");
+        </script>
+        <style>
+            body {
+                background: #000000;
+            }
+        </style>
+    </head>
+    <body>
+        Hello, World!
+    </body>
+</html>
+EOS
+    },
+    {
+        description => 'multiple <script>s in <head> & <body>, sha384',
+        config => {
+            do_csp => 'sha384',
+        },
+        csp => {
+            'script-src' => [qw(
+                'sha384-GmztkaupfNN5LCa4R3NR92UcwhOPA0C1u4dfOmu7LVDgWTK/nb06W1MXUmCXcC7d='
+                'sha384-2MKGGo4REN2gDPFYzCEFbsBLEaaGWN3NtW+5ss3IynhQy0gVzGNjPhIAaQkQsRzl='
+                'sha384-bMGstjmVvi+Hidcx4LpW/d3H8fNrKdkuh7zPgP7ygX/nKjqkKGgkJYFCgp7T91wP='
+                'sha384-8QFfvbKGXjYGVXD3XCs7As+GxXSe2QOYlCfZK0BwnXoRQnysSDUqmxiQl0gFz3Xv='
+            )],
+            'style-src' => [qw(
+            )],
+        },
+        html => <<'EOS',
+<html>
+    <head>
+        <script type="javascript">
+            alert("hello, world");
+        </script>
+    </head>
+    <body>
+        Hello, World!
+        <script type="text/javascript">
+            alert("bye, world");
+        </script>
+        <script type="text/javascript">
+            alert("this could be a stored XSS!");
+        </script>
+    </body>
+    <script type="javascript">
+        alert("carrier-injected code goes here");
+    </script>
+</html>
+EOS
+    },
+    {
+        description => 'multiple <style>s in <head> & <body>, sha512',
+        config => {
+            do_csp => 'sha512',
+            html5 => 1,
+        },
+        csp => {
+            'script-src' => [qw(
+            )],
+            'style-src' => [qw(
+                'sha512-p9OaSbAhJQugXiYS8mIifrN8EMZS/iS6kfXXRS3CJ4Wi2q5Swk43qD4qDHh2ZhNSQHCfMM0Nq5WSVCcJQJgzhA='
+                'sha512-Sjc3MfusJO7rZv+3DuUKu3BKqJSS7OH5/hD6hi6wmknbvPQIoKj1XjorMqvIh4cV+5G4wPGw8iyVqr+lM0o00w='
+                'sha512-jJo/nufQ7bS7CPfSlVJMOgIwWF+1xWwd+iHHV1XihxC+XK6iXZHB4CCJfyvQxxqWRMy7EjE14pAkLCPXEo1j0Q='
+                'sha512-sRmk48iK0P8JDwS5lnbl6J+QxUScQcljqlbZMEJsUkEuuA3023udi0n/v2thOx8Tkl5QVnGKa6PS8Oaopqg5pQ='
+            )],
+        },
+        html => <<'EOS',
+<html>
+    <head>
+        <style type="css">
+            body {
+                background: #000000;
+            }
+        </style>
+    </head>
+    <body>
+        Hello, World!
+        <style type="text/css">
+            p {
+                text-align: justify;
+            }
+        </style>
+        <style type="text/css">
+            strong {
+                color: blue;
+            }
+        </style>
+    </body>
+    <style type="css">
+        em {
+            color: black;
+        }
+    </style>
+</html>
+EOS
+    },
+    {
+        description => 'multiple <script>s & <style>s in head & body, sha384',
+        config => {
+            do_csp => 'sha384',
+        },
+        csp => {
+            'script-src' => [qw(
+                'sha384-GmztkaupfNN5LCa4R3NR92UcwhOPA0C1u4dfOmu7LVDgWTK/nb06W1MXUmCXcC7d='
+                'sha384-2MKGGo4REN2gDPFYzCEFbsBLEaaGWN3NtW+5ss3IynhQy0gVzGNjPhIAaQkQsRzl='
+                'sha384-bMGstjmVvi+Hidcx4LpW/d3H8fNrKdkuh7zPgP7ygX/nKjqkKGgkJYFCgp7T91wP='
+                'sha384-8QFfvbKGXjYGVXD3XCs7As+GxXSe2QOYlCfZK0BwnXoRQnysSDUqmxiQl0gFz3Xv='
+            )],
+            'style-src' => [qw(
+                'sha384-iJfw3xZ0S3zdRloWe4NmWzVDoRptkdiBAQ3B8XhDUw6VMlxC443ULkJgG5beMXu8='
+                'sha384-9fGbWIuKnbrRTHx7Vm3zJqCSQivir+TNWfFDmkdlCRwjC7VaaX2aYE+GNMt9uVB0='
+                'sha384-OB6G18VVZ1zX1cocqlzjU8ia9j9xghiouGtDlyW3fJ+BgWM1Sx+EeX2kkB7RksYB='
+                'sha384-ubt1ojP5OBH6ean6YYFy8fqGjFhh2vdAYgIqG15FG7YapFYCPqJfmOhQ+3wtvCVM='
+            )],
+        },
+        html => <<'EOS',
+<html>
+    <head>
+        <script type="javascript">
+            alert("hello, world");
+        </script>
+        <style type="text/css">
+            body {
+                background: #000000;
+            }
+        </style>
+    </head>
+    <body>
+        Hello, World!
+        <script type="text/javascript">
+            alert("bye, world");
+        </script>
+        <style type="text/css">
+            p {
+                text-align: justify;
+            }
+        </style>
+        <style type="text/css">
+            strong {
+                color: blue;
+            }
+        </style>
+        <script type="text/javascript">
+            alert("this could be a stored XSS!");
+        </script>
+    </body>
+    <script type="javascript">
+        alert("carrier-injected code goes here");
+    </script>
+    <style type="text/css">
+        em {
+            color: black;
+        }
+    </style>
+</html>
+EOS
+    },
+    {
+        description => 'unknown hash algorithm (no hash calculated)',
+        config => {
+            do_csp => 'unknown435',
+        },
+        csp => {
+            'script-src' => [qw(
+            )],
+            'style-src' => [qw(
+            )],
+        },
+        html => <<'EOS',
+<html>
+    <head>
+        <title>Hello!</title>
+        <script>
+            alert("hello, world");
+        </script>
+        <style>
+            body {
+                background: #000000;
+            }
+        </style>
+    </head>
+    <body>
+        Hello, World!
+    </body>
+</html>
+EOS
+    },
+);
+
+foreach my $test ( @tests ) {
+    my $packer = HTML::Packer->init;
+
+    my $html = $test->{html};
+    $packer->minify( \$html, $test->{config} );
+
+    is_deeply( { $packer->csp }, $test->{csp}, $test->{description} );
+}


### PR DESCRIPTION
Calculate hashes for embedded `<script>` and `<style>` tags, for use with the `script-src` and `style-src` directives of the `Content-Security-Policy` HTTP header, to mitigate cross-site scripting (XSS) attacks.

This belongs here, and not in `JS::Packer` and `CSS::Packer`, because hashes are only relevant for embedded scripts and stylesheets. Scripts and stylesheets served separately can be whitelisted by path, which is much simpler and more performant than hashing.

I originally implemented this as a derived module, and ran into #15.